### PR TITLE
changed Physical coordinate attributes to properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 branches:
   only:
   - master
+  - dev
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 # ratcave
-3D Graphics Engine running off Python, Psychopy, and Pyglet
+3D Graphics Engine running off Python, Psychopy, and Pyglet using modern OpenGL conventions.
 
 Full Documentation and Tutorials can be found at http://ratcave.readthedocs.io/
 

--- a/tests/test_physical.py
+++ b/tests/test_physical.py
@@ -61,9 +61,9 @@ class TestPhysical(unittest.TestCase):
 
         for scale in (5, 6, 7):
             phys = Physical(scale=scale)
-            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale).all())
-            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale).all())
-            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale).all())
+            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale))
 
     def test_scale_property_routing_causes_update_to_modelmatrix(self):
 


### PR DESCRIPTION
This lets us write 'Physical.position = 3, 4, 5' and not break anything, a common accident when typing code (currently, ratcave only lets you directly modify the position attribute).  So now, the following options are equivalent:

```python
Mesh.position.xyz = 1, 2, 3
Mesh.position[:] = 1, 2, 3
Mesh.position = 1, 2, 3
```