### PR TITLE
Mac

### DIFF
--- a/ratcave/physical.py
+++ b/ratcave/physical.py
@@ -5,7 +5,7 @@ import pyglet.gl as gl
 
 from . import coordinates
 from .utils import AutoRegisterObserver
-from .utils import mixins
+from .coordinates import Translation, RotationBase, Scale
 from .scenegraph import SceneGraph
 
 
@@ -33,6 +33,39 @@ class Physical(AutoRegisterObserver):
         self._model_matrix = np.identity(4, dtype=np.float32)
         self._normal_matrix = np.identity(4, dtype=np.float32)
         self._view_matrix = np.identity(4, dtype=np.float32)
+
+    @property
+    def position(self):
+        return self._position
+
+    @position.setter
+    def position(self, value):
+        if isinstance(value, Translation):
+            self._position = value
+        else:
+            self._position[:] = value
+
+    @property
+    def rotation(self):
+        return self._rotation
+
+    @rotation.setter
+    def rotation(self, value):
+        if isinstance(value, RotationBase):
+            self._rotation = value
+        else:
+            self._rotation[:] = value
+
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, value):
+        if isinstance(value, Scale):
+            self._scale = value
+        else:
+            self._scale[:] = value
 
     @property
     def model_matrix(self):

--- a/ratcave/vertex.py
+++ b/ratcave/vertex.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pyglet.gl as gl
 from .utils import BindingContextMixin, BindNoTargetMixin, BindTargetMixin, create_opengl_object, vec
-
+from sys import platform
 
 class VAO(BindingContextMixin, BindNoTargetMixin):
 
-    bindfun = gl.glBindVertexArray
+    bindfun = gl.glBindVertexArray if platform != 'darwin' else gl.glBindVertexArrayAPPLE
 
     def __init__(self, indices=None, **kwargs):
         """
@@ -22,7 +22,7 @@ class VAO(BindingContextMixin, BindNoTargetMixin):
 
         # Create Vertex Array Object and Bind it
         super(VAO, self).__init__(**kwargs)
-        self.id = create_opengl_object(gl.glGenVertexArrays)
+        self.id = create_opengl_object(gl.glGenVertexArrays if platform != 'darwin' else gl.glGenVertexArraysAPPLE)
         self.n_verts = None
 
         self.drawfun = self._draw_arrays

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -6,17 +6,17 @@ import pyglet
 
 def test_camera_physical_attributes():
     cam = Camera()
-    assert cam.position.xyz == (0, 0, 0)
-    assert cam.rotation.xyz == (0, 0, 0)
+    assert np.isclose(cam.position.xyz, (0, 0, 0)).all()
+    assert np.isclose(cam.rotation.xyz, (0, 0, 0)).all()
 
     cam.position.x = 1
-    assert cam.position.xyz == (1, 0, 0)
+    assert np.isclose(cam.position.xyz, (1, 0, 0)).all()
     assert np.all(cam.view_matrix[:3, -1] == tuple(-el for el in cam.position.xyz))
     assert np.all(cam.model_matrix[:3, -1] == cam.position.xyz)
 
 
     cam.rotation.y = 30
-    assert cam.rotation.xyz == (0, 30, 0)
+    assert np.isclose(cam.rotation.xyz, (0, 30, 0)).all()
     assert cam.rotation.y == 30
 
 

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -19,16 +19,15 @@ class TestMesh(unittest.TestCase):
 
     def test_position_update_to_modelmatrix(self):
 
-
         for pos in [(4,5, 6), (5, 4, 1)]:
             mesh = self.reader.get_mesh("Cube", position=pos)
-            self.assertEqual(mesh.position.xyz, pos)
-            # self.assertTrue(np.isclose(mesh.uniforms['model_matrix'][:3, 3], pos).all())
+            self.assertTrue(np.isclose(mesh.position.xyz, pos).all())
+            self.assertTrue(np.isclose(mesh.uniforms['model_matrix'][:3, 3], pos).all())
 
         for pos in [(4,5, 6), (5, 4, 1)]:
             mesh = self.mesh
             mesh.position.xyz = pos
-            self.assertEqual(mesh.position.xyz, pos)
+            self.assertTrue(np.isclose(mesh.position.xyz, pos).all())
             self.assertTrue(np.isclose(mesh.uniforms['model_matrix'][:3, 3], pos).all())
 
 
@@ -37,25 +36,25 @@ class TestMesh(unittest.TestCase):
         mesh = self.mesh
         for pos in [(4,5, 6), (5, 4, 1)]:
             mesh.position.x, mesh.position.y, mesh.position.z = pos
-            self.assertEqual(mesh.position.xyz, pos)
+            self.assertTrue(np.isclose(mesh.position.xyz, pos).all())
 
     def test_rotation_update(self):
 
         mesh = self.mesh
         for rot in [(4, 5, 6), (5, 4, 1)]:
             mesh.rotation.x, mesh.rotation.y, mesh.rotation.z = rot
-            self.assertEqual(mesh.rotation.xyz, rot)
+            self.assertTrue(np.isclose(mesh.rotation.xyz, rot).all())
 
     def test_scale_update(self):
 
         mesh = self.mesh
         for rot in [(4, 5, 6), (5, 4, 1)]:
             mesh.scale.x, mesh.scale.y, mesh.scale.z = rot
-            self.assertEqual(mesh.scale.xyz, rot)
+            self.assertTrue(np.isclose(mesh.scale.xyz, rot).all())
 
         for rot in [4, 5]:
             mesh.scale.xyz = rot
-            self.assertEqual(mesh.scale.xyz, (rot, rot, rot))
+            self.assertTrue(np.isclose(mesh.scale.xyz, (rot, rot, rot)).all())
 
 
 @pytest.fixture()

--- a/tests/test_physical.py
+++ b/tests/test_physical.py
@@ -61,9 +61,9 @@ class TestPhysical(unittest.TestCase):
 
         for scale in (5, 6, 7):
             phys = Physical(scale=scale)
-            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale).all())
-            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale).all())
-            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale).all())
+            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale))
 
     def test_scale_property_routing_causes_update_to_modelmatrix(self):
 

--- a/tests/test_physical.py
+++ b/tests/test_physical.py
@@ -25,6 +25,14 @@ class TestPhysical(unittest.TestCase):
             self.assertEqual(phys.position.xyz, pos)
             self.assertTrue(np.isclose(phys.model_matrix[:3, 3], pos).all())
 
+    def test_position_property_routing_causes_update_to_modelmatrix(self):
+
+        for pos in [(4, 5, 6), (5, 4, 1)]:
+            phys = Physical()
+            phys.position = pos
+            self.assertEqual(phys.position.xyz, pos)
+            self.assertTrue(np.isclose(phys.model_matrix[:3, 3], pos).all())
+
     def test_rotation_update(self):
 
         for rot in [(4, 5, 6), (5, 4, 1)]:
@@ -35,10 +43,26 @@ class TestPhysical(unittest.TestCase):
             phys.rotation.xyz = rot
             self.assertEqual(phys.rotation.xyz, rot)
 
+    def test_rotation_property_routing_causes_update_to_modelmatrix(self):
+
+        for rot in [(4, 5, 6), (5, 4, 1)]:
+            phys = Physical()
+            phys.rotation = rot
+            self.assertEqual(phys.rotation.xyz, rot)
+
     def test_scale_update_to_modelmatrix(self):
 
         for scale in (5, 6, 7):
             phys = Physical(scale=scale)
+            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale))
+
+    def test_scale_property_routing_causes_update_to_modelmatrix(self):
+
+        for scale in (5, 6, 7):
+            phys = Physical()
+            phys.scale = scale
             self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale))
             self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale))
             self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale))

--- a/tests/test_physical.py
+++ b/tests/test_physical.py
@@ -16,32 +16,39 @@ class TestPhysical(unittest.TestCase):
 
         for pos in [(4,5, 6), (5, 4, 1)]:
             phys = Physical(position=pos)
-            self.assertEqual(phys.position.xyz, pos)
+            self.assertTrue(np.isclose(phys.position.xyz, pos).all())
+            self.assertTrue(np.isclose(phys.position.zyx, pos[::-1]).all())
             self.assertTrue(np.isclose(phys.model_matrix[:3, 3], pos).all())
 
         for pos in [(4,5, 6), (5, 4, 1)]:
             phys = Physical()
             phys.position.xyz = pos
-            self.assertEqual(phys.position.xyz, pos)
+            self.assertTrue(np.isclose(phys.position.xyz, pos).all())
+            self.assertTrue(np.isclose(phys.position.zyx, pos[::-1]).all())
             self.assertTrue(np.isclose(phys.model_matrix[:3, 3], pos).all())
+
+        for pos in [4, 5]:
+            phys = Physical()
+            phys.position.xxx = pos
+            self.assertTrue(np.isclose(phys.model_matrix[:3, 3], (pos, 0, 0)).all())
 
     def test_rotation_update(self):
 
         for rot in [(4, 5, 6), (5, 4, 1)]:
             phys = Physical(rotation=rot)
-            self.assertEqual(phys.rotation.xyz, rot)
+            self.assertTrue(np.isclose(phys.rotation.xyz, rot).all())
 
         for rot in [(4, 5, 6), (5, 4, 1)]:
             phys.rotation.xyz = rot
-            self.assertEqual(phys.rotation.xyz, rot)
+            self.assertTrue(np.isclose(phys.rotation.xyz, rot).all())
 
     def test_scale_update_to_modelmatrix(self):
 
         for scale in (5, 6, 7):
             phys = Physical(scale=scale)
-            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale))
-            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale))
-            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale))
+            self.assertTrue(np.isclose(phys.model_matrix[0, 0], scale).all())
+            self.assertTrue(np.isclose(phys.model_matrix[1, 1], scale).all())
+            self.assertTrue(np.isclose(phys.model_matrix[2, 2], scale).all())
 
 
 class TestModelViewNormalMatrices(unittest.TestCase):


### PR DESCRIPTION
After digging around, I found that the only functions that needed adapting for Mac use were glVertexArrays (which worked when changed to glVertexArraysAPPLE) and glBindVertexArray (once again, to glBindVertexArrayAPPLE).  The tutorials now run just fine with those changes, so I simply added a check for the platform when using those functions and substitute the correct one.  If we find more changes are necessary in the future, a more robust function substitution (similar to Pyglet's approach, perhaps) may be necessary.