### PR TITLE
Numpy gets built later now, without the need for pre-installation!

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Full Documentation and Tutorials can be found at http://ratcave.readthedocs.io/
 
 ## Installation
 ```
-pip install pyglet numpy ratcave
+pip install ratcave
 ```
 
 ## Features


### PR DESCRIPTION
Fixes issue where a custom warning about installing numpy would appear on fresh virtual environments.  It should make ratcave a single-step installation process.