### PR TITLE
2D Textures now handled through Numpy arrays

### DIFF
--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -10,6 +10,8 @@ cube = rc.Mesh.from_primitive('Cube', position=(0, 0, -3), rotation=(45, 45, 0))
 arr = np.random.randint(0, 255, size=(128, 128, 4))
 
 tex2 = rc.Texture(values=arr)
+tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
+
 
 cube.textures.append(tex2)
 

--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -1,10 +1,6 @@
-import matplotlib.pyplot as plt
 import numpy as np
 import pyglet
 import ratcave as rc
-from pyglet.extlibs import png
-import pyglet.gl as gl
-
 
 
 window = pyglet.window.Window()

--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -11,9 +11,9 @@ window = pyglet.window.Window()
 
 cube = rc.Mesh.from_primitive('Cube', position=(0, 0, -3), rotation=(45, 45, 0))
 
-arr = np.random.randint(0, 255, size=(1024, 1024, 4))
+arr = np.random.randint(0, 255, size=(128, 128, 4))
 
-tex2 = rc.Texture(width=arr.shape[1], height=arr.shape[0], values=arr)
+tex2 = rc.Texture(values=arr)
 
 cube.textures.append(tex2)
 
@@ -25,7 +25,7 @@ def on_draw():
 
 
 def randomize_texture(dt):
-    tex2.values = np.random.randint(0, 255, size=(1024, 1024, 4))
+    tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
 pyglet.clock.schedule(randomize_texture)
 
 pyglet.app.run()

--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -12,8 +12,7 @@ arr = np.zeros_like(arr)# + 255
 arr[:, :, 0] = 255
 
 tex2 = rc.Texture(values=arr)
-# tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
-
+tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
 
 cube.textures.append(tex2)
 
@@ -24,8 +23,8 @@ def on_draw():
         cube.draw()
 
 
-# def randomize_texture(dt):
-#     tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
-# pyglet.clock.schedule(randomize_texture)
+def randomize_texture(dt):
+    tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
+pyglet.clock.schedule(randomize_texture)
 
 pyglet.app.run()

--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -8,9 +8,11 @@ window = pyglet.window.Window()
 cube = rc.Mesh.from_primitive('Cube', position=(0, 0, -3), rotation=(45, 45, 0))
 
 arr = np.random.randint(0, 255, size=(128, 128, 4))
+arr = np.zeros_like(arr)# + 255
+arr[:, :, 0] = 255
 
 tex2 = rc.Texture(values=arr)
-tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
+# tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
 
 
 cube.textures.append(tex2)
@@ -22,8 +24,8 @@ def on_draw():
         cube.draw()
 
 
-def randomize_texture(dt):
-    tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
-pyglet.clock.schedule(randomize_texture)
+# def randomize_texture(dt):
+#     tex2.values = np.random.randint(0, 255, size=(128, 128, 4))
+# pyglet.clock.schedule(randomize_texture)
 
 pyglet.app.run()

--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -2,24 +2,20 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyglet
 import ratcave as rc
+from pyglet.extlibs import png
+import pyglet.gl as gl
+
 
 
 window = pyglet.window.Window()
 
-cube = rc.Mesh.from_primitive('Cube', position=(0, 0, -3))
+cube = rc.Mesh.from_primitive('Cube', position=(0, 0, -3), rotation=(45, 45, 0))
 
+arr = np.random.randint(0, 255, size=(1024, 1024, 4))
 
-# image = pyglet.image.load(rc.resources.img_colorgrid)
-# data = image.get_image_data()
-# arr = np.ndarray(buffer=data.data,
-#            shape=(image.height, image.width, len(image.format)),
-#            dtype=np.uint8)
+tex2 = rc.Texture(width=arr.shape[1], height=arr.shape[0], values=arr)
 
-tex = rc.Texture.from_image(rc.resources.img_colorgrid)
-arr = tex.values
-print("Texture Array Shape: {}".format(arr.shape))
-
-cube.textures.append(tex)
+cube.textures.append(tex2)
 
 @window.event
 def on_draw():
@@ -28,9 +24,8 @@ def on_draw():
         cube.draw()
 
 
-def rotate_cube(dt):
-    cube.rotation.x += 15 * dt
-    cube.rotation.y += 30 * dt
-pyglet.clock.schedule(rotate_cube)
+def randomize_texture(dt):
+    tex2.values = np.random.randint(0, 255, size=(1024, 1024, 4))
+pyglet.clock.schedule(randomize_texture)
 
 pyglet.app.run()

--- a/examples/gen_texture_from_array.py
+++ b/examples/gen_texture_from_array.py
@@ -1,0 +1,36 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyglet
+import ratcave as rc
+
+
+window = pyglet.window.Window()
+
+cube = rc.Mesh.from_primitive('Cube', position=(0, 0, -3))
+
+
+# image = pyglet.image.load(rc.resources.img_colorgrid)
+# data = image.get_image_data()
+# arr = np.ndarray(buffer=data.data,
+#            shape=(image.height, image.width, len(image.format)),
+#            dtype=np.uint8)
+
+tex = rc.Texture.from_image(rc.resources.img_colorgrid)
+arr = tex.values
+print("Texture Array Shape: {}".format(arr.shape))
+
+cube.textures.append(tex)
+
+@window.event
+def on_draw():
+    window.clear()
+    with rc.default_shader, rc.default_camera, rc.default_states:
+        cube.draw()
+
+
+def rotate_cube(dt):
+    cube.rotation.x += 15 * dt
+    cube.rotation.y += 30 * dt
+pyglet.clock.schedule(rotate_cube)
+
+pyglet.app.run()

--- a/examples/tutorial1.py
+++ b/examples/tutorial1.py
@@ -17,6 +17,9 @@ obj_reader = rc.WavefrontReader(obj_filename)
 monkey = obj_reader.get_mesh("Monkey")
 monkey.position.xyz = 0, 0, -3
 
+tex = rc.Texture.from_image(rc.resources.img_colorgrid)
+monkey.textures.append(tex)
+
 # Create Scene
 scene = rc.Scene(meshes=[monkey])
 

--- a/ratcave/texture.py
+++ b/ratcave/texture.py
@@ -56,15 +56,13 @@ class Texture(HasUniforms, BindTargetMixin):
 
     @property
     def values(self):
-        if hasattr(self, 'data'):
-            data = self.data.get_image_data()
-            return np.ndarray(buffer=data.data, shape=(data.height, data.width, len(data.format)), dtype=np.uint8)#, order='C')
-        else:
-            raise NotImplementedError("Textures currently only have a 'values' if created from_image().")
+        return self._values
 
     @values.setter
     def values(self, values):
         arr = np.array(values).astype(np.uint8)
+        arr.setflags(write=False)
+
         if arr.shape != (self.height, self.height, 4):
             raise ValueError("Texture.values shape must match shape: width x height x 4 (RGBA)")
 

--- a/ratcave/texture.py
+++ b/ratcave/texture.py
@@ -12,11 +12,12 @@ class Texture(HasUniforms, BindTargetMixin):
     target0 = gl.GL_TEXTURE_2D
     attachment_point = gl.GL_COLOR_ATTACHMENT0_EXT
     internal_fmt = gl.GL_RGBA
-    pixel_fmt=gl.GL_RGBA
+    pixel_fmt = gl.GL_RGBA
     _slot_counter = itertools.count(start=1)
     bindfun = gl.glBindTexture
 
-    def __init__(self, id=None, name='TextureMap', width=1024, height=1024, data=None, mipmap=False, values=None, **kwargs):
+    def __init__(self, id=None, name='TextureMap', width=1024, height=1024, data=None, mipmap=False, values=None,
+                 **kwargs):
         """2D Color Texture class. Width and height can be set, and will generate a new OpenGL texture if no id is given."""
         super(Texture, self).__init__(**kwargs)
 
@@ -63,10 +64,7 @@ class Texture(HasUniforms, BindTargetMixin):
     def values(self):
         if hasattr(self, 'data'):
             data = self.data.get_image_data()
-            arr = np.ndarray(buffer=data.data,
-                       shape=(data.height, data.width, len(data.format)),
-                       dtype=np.uint8)
-            return arr
+            return np.ndarray(buffer=data.data, shape=(data.height, data.width, len(data.format)), dtype=np.uint8)
         else:
             raise NotImplementedError("Textures currently only have a 'values' if created from_image().")
 
@@ -81,17 +79,13 @@ class Texture(HasUniforms, BindTargetMixin):
                                (gl.GLubyte * arr.size)(*arr.flatten().astype('uint8'))
                                )
 
-
-
-
-
     def bind(self):
         gl.glActiveTexture(gl.GL_TEXTURE0 + self.slot)
         super(Texture, self).bind()
         self.uniforms['{}_isBound'.format(self.name)] = True
         try:
             self.uniforms.send()
-        except UnboundLocalError:  # TODO: Find a way to make binding and uniform-sending simple without requiring a bound shader.
+        except UnboundLocalError:
             pass
 
     def unbind(self):
@@ -99,7 +93,7 @@ class Texture(HasUniforms, BindTargetMixin):
         self.uniforms['{}_isBound'.format(self.name)] = False
         try:
             self.uniforms.send()
-        except UnboundLocalError:  # TODO: Find a way to make binding and uniform-sending simple without requiring a bound shader.
+        except UnboundLocalError:
             pass
 
         gl.glActiveTexture(gl.GL_TEXTURE0)

--- a/ratcave/texture.py
+++ b/ratcave/texture.py
@@ -16,7 +16,7 @@ class Texture(HasUniforms, BindTargetMixin):
     _slot_counter = itertools.count(start=1)
     bindfun = gl.glBindTexture
 
-    def __init__(self, id=None, name='TextureMap', width=1024, height=1024, data=None, mipmap=False, **kwargs):
+    def __init__(self, id=None, name='TextureMap', width=1024, height=1024, data=None, mipmap=False, values=None, **kwargs):
         """2D Color Texture class. Width and height can be set, and will generate a new OpenGL texture if no id is given."""
         super(Texture, self).__init__(**kwargs)
 
@@ -38,6 +38,9 @@ class Texture(HasUniforms, BindTargetMixin):
             self._apply_filter_settings()
 
         self.unbind()
+
+        if type(values) != type(None):
+            self.values = values
 
     @property
     def name(self):
@@ -64,6 +67,19 @@ class Texture(HasUniforms, BindTargetMixin):
             return arr
         else:
             raise NotImplementedError("Textures currently only have a 'values' if created from_image().")
+
+    @values.setter
+    def values(self, values):
+        arr = np.array(values).astype(np.uint8)
+        if arr.shape != (self.height, self.height, 4):
+            raise ValueError("Texture.values shape must match shape: width x height x 4 (RGBA)")
+        with self:
+            gl.glTexSubImage2D(gl.GL_TEXTURE_2D, 0, 0, 0, self.width, self.height,
+                               gl.GL_RGBA, gl.GL_UNSIGNED_INT_8_8_8_8,
+                               (gl.GLubyte * arr.size)(*arr.flatten().astype('uint8'))
+                               )
+
+
 
 
 

--- a/ratcave/texture.py
+++ b/ratcave/texture.py
@@ -2,6 +2,7 @@ import itertools
 from .utils import BindTargetMixin, BindingContextMixin, create_opengl_object
 import pyglet
 import pyglet.gl as gl
+import numpy as np
 from .shader import HasUniforms
 
 
@@ -52,6 +53,18 @@ class Texture(HasUniforms, BindTargetMixin):
         self.uniforms[name] = self._slot
         self.uniforms[name + '_isBound'] = False
         self._name = name
+
+    @property
+    def values(self):
+        if hasattr(self, 'data'):
+            data = self.data.get_image_data()
+            arr = np.ndarray(buffer=data.data,
+                       shape=(data.height, data.width, len(data.format)),
+                       dtype=np.uint8)
+            return arr
+        else:
+            raise NotImplementedError("Textures currently only have a 'values' if created from_image().")
+
 
 
     def bind(self):

--- a/ratcave/texture.py
+++ b/ratcave/texture.py
@@ -31,6 +31,8 @@ class Texture(HasUniforms, BindTargetMixin):
             self.data = data  # This is used for anything that might be garbage collected (i.e. pyglet textures)
         else:
             self.id = create_opengl_object(gl.glGenTextures)
+            if type(values) != type(None):
+                width, height = values.shape[1], values.shape[0]
             self.width = width
             self.height = height
             self.bind()


### PR DESCRIPTION
Texture objects now have a height x width x 4 'values' array attribute that can be overwritten in order to send Numpy data directly to the GPU. This can be seen in the new gen_texture_from_array.py example script.