### PR TITLE
Enums for gl functions

### DIFF
--- a/examples/ortho_demo.py
+++ b/examples/ortho_demo.py
@@ -12,6 +12,7 @@ cam.projection = rc.OrthoProjection(coords='relative', origin='corner')
 
 @window.event
 def on_draw():
+    window.clear()
     with rc.default_shader, rc.default_states, cam:
         cube.draw()
 

--- a/examples/structure_from_motion2_demo.py
+++ b/examples/structure_from_motion2_demo.py
@@ -8,7 +8,7 @@ width, height = 0.2, 0.5
 theta = random(n_points) * np.pi * 2
 verts = np.vstack((np.sin(theta) * width, (random(n_points) - .5) * height, np.cos(theta) * width)).T
 
-cylinder = rc.Mesh.from_incomplete_data(verts, drawmode=rc.POINTS, position=(0, 0, -2), point_size=2, mean_center=False)
+cylinder = rc.Mesh.from_incomplete_data(verts, drawmode=rc.gl.GL_POINTS, position=(0, 0, -2), point_size=2, mean_center=False)
 cylinder.uniforms['diffuse'] = 1., 1., 1.
 cylinder.uniforms['flat_shading'] = True
 cylinder.point_size = .02

--- a/examples/structure_from_motion_demo.py
+++ b/examples/structure_from_motion_demo.py
@@ -8,7 +8,7 @@ width, height = 0.2, 0.5
 theta = random(n_points) * np.pi * 2
 verts = np.vstack((np.sin(theta) * width, (random(n_points) - .5) * height, np.cos(theta) * width)).T
 
-cylinder = rc.Mesh.from_incomplete_data(verts, position=(0, 0, -2), mean_center=False, drawmode=rc.POINTS, point_size=.02)
+cylinder = rc.Mesh.from_incomplete_data(verts, position=(0, 0, -2), mean_center=False, drawmode=rc.gl.GL_POINTS, point_size=.02)
 cylinder.uniforms['diffuse'] = 1., 1., 1.
 cylinder.uniforms['flat_shading'] = True
 cylinder.rotation.x = 20

--- a/examples/structure_from_motion_psychopy_demo.py
+++ b/examples/structure_from_motion_psychopy_demo.py
@@ -8,7 +8,7 @@ width, height = 0.2, 0.5
 theta = random(n_points) * np.pi * 2
 verts = np.vstack((np.sin(theta) * width, (random(n_points) - .5) * height, np.cos(theta) * width)).T
 
-cylinder = rc.Mesh.from_incomplete_data(verts, drawmode=rc.POINTS, position=(0, 0, -2), point_size=2, mean_center=False)
+cylinder = rc.Mesh.from_incomplete_data(verts, drawmode=rc.gl.GL_POINTS, position=(0, 0, -2), point_size=2, mean_center=False)
 cylinder.uniforms['diffuse'] = 1., 1., 1.
 cylinder.uniforms['flat_shading'] = True
 

--- a/ratcave/__init__.py
+++ b/ratcave/__init__.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import
 
-from .coordinates import RotationEulerDegrees, RotationQuaternion, RotationEulerRadians, Translation, Scale
-
+from . import utils
+from .utils import gl as gl
+from .utils.gl import POINTS, LINE_LOOP, LINES, TRIANGLES, clear_color
 try:
     from . import resources
     from .resources import default_shader, default_camera, default_light
 except ImportError:
     pass
-from . import utils
+from .coordinates import RotationEulerDegrees, RotationQuaternion, RotationEulerRadians, Translation, Scale
 from .camera import Camera, PerspectiveProjection, OrthoProjection, CameraGroup, StereoCameraGroup
 from .collision import ColliderSphere, ColliderCube, ColliderCylinder
 from .fbo import FBO
@@ -20,7 +21,6 @@ from .scene import Scene
 from .shader import Shader, UniformCollection
 from .texture import Texture, TextureCube, DepthTexture
 from .scenegraph import SceneGraph
-from .utils.gl import POINTS, LINE_LOOP, LINES, TRIANGLES, clear_color
 from . import experimental
 from .wavefront import WavefrontReader
 

--- a/ratcave/__init__.py
+++ b/ratcave/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from . import utils
 from .utils import gl as gl
-from .utils.gl import POINTS, LINE_LOOP, LINES, TRIANGLES, clear_color
+from .utils.gl import clear_color
 try:
     from . import resources
     from .resources import default_shader, default_camera, default_light

--- a/ratcave/camera.py
+++ b/ratcave/camera.py
@@ -2,7 +2,6 @@ import pickle
 import abc
 import numpy as np
 from .physical import PhysicalGraph
-import pyglet.gl as gl
 from collections import namedtuple
 from .shader import HasUniformsUpdater
 from .utils import NameLabelMixin, get_viewport

--- a/ratcave/collision.py
+++ b/ratcave/collision.py
@@ -1,6 +1,6 @@
 import abc
 import numpy as np
-import pyglet.gl as gl
+from . import gl
 from .mesh import Mesh
 
 

--- a/ratcave/experimental.py
+++ b/ratcave/experimental.py
@@ -1,4 +1,4 @@
-import pyglet.gl as gl
+from . import gl
 
 
 def draw_vr_anaglyph(cube_fbo, vr_scene, active_scene, eye_poses=(.035, -.035)):

--- a/ratcave/fbo.py
+++ b/ratcave/fbo.py
@@ -2,7 +2,7 @@
 from .utils import BindingContextMixin, create_opengl_object, get_viewport, Viewport
 from .texture import DepthTexture, RenderBuffer
 
-import pyglet.gl as gl
+from . import gl
 
 
 class FBO(BindingContextMixin):

--- a/ratcave/gl_states.py
+++ b/ratcave/gl_states.py
@@ -1,4 +1,4 @@
-import pyglet.gl as gl
+from . import gl
 
 
 class GLStateManager(object):

--- a/ratcave/mesh.py
+++ b/ratcave/mesh.py
@@ -6,13 +6,10 @@ import pickle
 import numpy as np
 from .utils import vertices as vertutils
 from .utils import NameLabelMixin
-from . import physical, shader
+from . import physical, shader, gl
 from .texture import Texture
 from .vertex import VAO, VBO
-import pyglet.gl as gl
 from copy import deepcopy
-from warnings import warn
-
 
 
 def gen_fullscreen_quad(name='FullScreenQuad'):
@@ -117,8 +114,9 @@ class Mesh(shader.HasUniformsUpdater, physical.PhysicalGraph, NameLabelMixin):
     def from_pickle(cls, filename):
         """Loads and Returns a Mesh from a pickle file, given a filename."""
         with open(filename, 'rb') as f:
-            mesh = pickle.load(f).copy()
-        return mesh
+            mesh = pickle.load(f)
+            mesh2 = mesh.copy()
+        return mesh2
 
     @classmethod
     def from_primitive(cls, name, position=(0, 0, 0), **kwargs):

--- a/ratcave/mesh.py
+++ b/ratcave/mesh.py
@@ -33,9 +33,6 @@ class EmptyEntity(shader.HasUniformsUpdater, physical.PhysicalGraph, NameLabelMi
 
 class Mesh(shader.HasUniformsUpdater, physical.PhysicalGraph, NameLabelMixin):
 
-    triangles = gl.GL_TRIANGLES
-    points = gl.GL_POINTS
-
 
     def __init__(self, arrays, textures=(), mean_center=True,
                  gl_states=(), drawmode=gl.GL_TRIANGLES, point_size=15, dynamic=False, visible=True, **kwargs):

--- a/ratcave/physical.py
+++ b/ratcave/physical.py
@@ -1,7 +1,7 @@
 import _transformations as trans
 
 import numpy as np
-import pyglet.gl as gl
+from . import gl
 
 from . import coordinates
 from .utils import AutoRegisterObserver

--- a/ratcave/scene.py
+++ b/ratcave/scene.py
@@ -1,4 +1,4 @@
-import pyglet.gl as gl
+from . import gl
 from . import Camera, Light, Mesh, EmptyEntity
 from .texture import TextureCube
 from .utils import mixins, clear_color

--- a/ratcave/texture.py
+++ b/ratcave/texture.py
@@ -1,7 +1,7 @@
 import itertools
 from .utils import BindTargetMixin, BindingContextMixin, create_opengl_object
 import pyglet
-import pyglet.gl as gl
+from . import gl
 import numpy as np
 from .shader import HasUniforms
 

--- a/ratcave/utils/__init__.py
+++ b/ratcave/utils/__init__.py
@@ -1,6 +1,5 @@
-from . import gl
 from . import vertices
-from .gl import vec, create_opengl_object, POINTS, TRIANGLES, LINE_LOOP, LINES, get_viewport, Viewport, clear_color
+from .gl import *
 from .mixins import NameLabelMixin, BindTargetMixin, BindNoTargetMixin, BindingContextMixin
 from .observers import Observable, Observer, IterObservable, AutoRegisterObserver
 

--- a/ratcave/utils/gl.py
+++ b/ratcave/utils/gl.py
@@ -1,17 +1,39 @@
-import pyglet.gl as gl
+import pyglet.gl as pyglet_gl
 from ctypes import byref
 from collections import namedtuple
+import itertools as it
+
+POINTS = pyglet_gl.GL_POINTS
+TRIANGLES = pyglet_gl.GL_TRIANGLES
+LINE_LOOP = pyglet_gl.GL_LINE_LOOP
+LINES = pyglet_gl.GL_LINES
 
 
-POINTS = gl.GL_POINTS
-TRIANGLES = gl.GL_TRIANGLES
-LINE_LOOP = gl.GL_LINE_LOOP
-LINES = gl.GL_LINES
+class Enum(int):
+    """Prints enum name, instead of the int value.  Makes working with OpenGL easier."""
+    def __new__(cls, name_value, *args, **kwargs):
+        if isinstance(name_value, int) and name_value == 4:  # Because of some not-understood behavior during pickle.load()
+            return super(Enum, cls).__new__(cls, name_value)
+        name, value = name_value
+        obj = super(Enum, cls).__new__(cls, value)
+        obj.name = name
+        return obj
+
+    def __repr__(self):
+        return self.name
+
+for module in [pyglet_gl, pyglet_gl.gl]:
+    for name in dir(module):
+        attr = getattr(module, name)
+        if isinstance(getattr(module, name), int):
+            locals()[name] = Enum((name, attr))
+        elif not name.startswith('_') and name not in ['pyglet', 'gl']:
+            locals()[name] = attr
 
 
 def create_opengl_object(gl_gen_function, n=1):
     """Returns int pointing to an OpenGL texture"""
-    handle = gl.GLuint(1)
+    handle = pyglet_gl.GLuint(1)
     gl_gen_function(n, byref(handle))  # Create n Empty Objects
     if n > 1:
         return [handle.value + el for el in range(n)]  # Return list of handle values
@@ -23,13 +45,13 @@ def vec(data, dtype=float):
         """ Makes GLfloat or GLuint vector containing float or uint args.
         By default, newtype is 'float', but can be set to 'int' to make
         uint list. """
-        gl_types = {float: gl.GLfloat, int: gl.GLuint}
+        gl_types = {float: pyglet_gl.GLfloat, int: pyglet_gl.GLuint}
         try:
             gl_dtype = gl_types[dtype]
         except KeyError:
             raise TypeError('dtype not recognized.  Recognized types are int and float')
 
-        if gl_dtype == gl.GLuint:
+        if gl_dtype == pyglet_gl.GLuint:
             for el in data:
                 if el < 0:
                     raise ValueError("integer ratcave.vec arrays are unsigned--negative values are not supported.")
@@ -40,11 +62,11 @@ def vec(data, dtype=float):
 Viewport = namedtuple('Viewport', 'x y width height')
 
 def get_viewport():
-    data = (gl.GLint * 4)()
-    gl.glGetIntegerv(gl.GL_VIEWPORT, data)
+    data = (pyglet_gl.GLint * 4)()
+    pyglet_gl.glGetIntegerv(pyglet_gl.GL_VIEWPORT, data)
     return Viewport(*data)
 
 
 def clear_color(r, g, b):
-    gl.glClearColor(r, g, b, 1.)
-    gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+    pyglet_gl.glClearColor(r, g, b, 1.)
+    pyglet_gl.glClear(pyglet_gl.GL_COLOR_BUFFER_BIT | pyglet_gl.GL_DEPTH_BUFFER_BIT)

--- a/ratcave/utils/gl.py
+++ b/ratcave/utils/gl.py
@@ -3,11 +3,6 @@ from ctypes import byref
 from collections import namedtuple
 import itertools as it
 
-POINTS = pyglet_gl.GL_POINTS
-TRIANGLES = pyglet_gl.GL_TRIANGLES
-LINE_LOOP = pyglet_gl.GL_LINE_LOOP
-LINES = pyglet_gl.GL_LINES
-
 
 class Enum(int):
     """Prints enum name, instead of the int value.  Makes working with OpenGL easier."""

--- a/ratcave/vertex.py
+++ b/ratcave/vertex.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pyglet.gl as gl
+from . import gl
 from .utils import BindingContextMixin, BindNoTargetMixin, BindTargetMixin, create_opengl_object, vec
 from sys import platform
 


### PR DESCRIPTION
It's confusing to understand what gl enums were used in Ratcave, whether reading the docs, the help text, or even just checking the values.  This is a simple patch that replaces all the pyglet.gl enums with an Enum class that subclasses int and prints the name.   it also means that users can use pyglet.gl or ratcave.gl interchangeable, and opens possibilities for future devleopment using PyOpenGL, which does the Enum thing already, instead of pyglet.gl.