### PR TITLE
Pyglet 1.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='ratcave',
       package_data={'': ['../assets/*.'+el for el in ['png', 'obj', 'mtl']] +
                         ['../shaders/*/*'+el for el in ['vert', 'frag']]
                     },
-      install_requires=['pyglet<2.0', 'numpy', 'wavefront_reader', 'future', 'six'],
+      install_requires=['pyglet==1.3.3', 'numpy', 'wavefront_reader', 'future', 'six'],
       cmdclass={'build_ext':build_ext},
       ext_modules=[Extension('_transformations', sources=['third_party/transformations.c'])],#, include_dirs=[numpy.get_include()])],
       setup_requires=['numpy', 'pytest-runner'],


### PR DESCRIPTION
Hi, 
Limit Pyglet version to correct error message from Pyglet>1.4
```
C:\Users\mebarkiy\Miniconda3\envs\Ratcave\python.exe C:/Users/mebarkiy/Documents/Ratcave/examples/solar_system.py
Traceback (most recent call last):
  File "C:/Users/mebarkiy/Documents/Ratcave/examples/solar_system.py", line 59, in <module>
    sun.textures.append(rc.Texture.from_image(rc.resources.img_colorgrid))
  File "C:\Users\mebarkiy\Documents\Ratcave\ratcave\texture.py", line 144, in from_image
    arr = np.ndarray(buffer=img.get_image_data().data, shape=(img.height, img.width, 4), dtype=np.uint8)
AttributeError: 'ImageData' object has no attribute 'data'
```