### PR TITLE
Replaced `as_dcm()` with `as_matrix()` in `coordinates.py`. Also fixed SyntaxWarning in `physical.py`

### DIFF
--- a/ratcave/coordinates.py
+++ b/ratcave/coordinates.py
@@ -92,7 +92,13 @@ class RotationEulerRadians(RotationEuler):
 
     def to_matrix(self):
         mat = np.eye(4)
-        mat[:3, :3] = R.from_euler(self.axes[1:],self._array,degrees=False).as_dcm() # scipy as_matrix() not available
+        res = R.from_euler(self.axes[1:],self._array,degrees=False)
+        try:
+            res=res.as_matrix()#Adjusted for the newest scipy version
+        except AttributeError:
+            res=res.as_dcm()#Older version
+
+        mat[:3, :3] = res 
         return mat
 
     def to_euler(self, units='rad'):

--- a/ratcave/physical.py
+++ b/ratcave/physical.py
@@ -28,7 +28,7 @@ class Physical(AutoRegisterObserver):
                 raise ValueError("Scale can not be set to 0")
             self.scale = coordinates.Scale(*scale)
         else:
-            if scale is 0:
+            if scale == 0:
                 raise ValueError("Scale can not be set to 0")
             self.scale = coordinates.Scale(scale)
 


### PR DESCRIPTION
I added `try: expect:` block to check if method `as_matrix()` exists, if it does not, use `as_dcm()`.
`as_dcm()` was replaced with `as_matrix()` in [scipy 1.4.0](https://github.com/scipy/scipy/blob/5f4c4d802e5a56708d86909af6e5685cd95e6e66/doc/release/1.4.0-notes.rst)

I also fixed the SyntaxWarning , replaced `if scale is 0:` with `if scale==0:`